### PR TITLE
Fixes exception thrown when attempting to process an image caused by libjep.so not in the library path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ RUN pip install numpy --target /home/kogito/.local/bin
 RUN pip install -r requirements.txt --target /home/kogito/.local/bin
 
 ENV QUARKUS_EXTENSIONS="org.kie.kogito:kogito-addons-quarkus-serverless-workflow-python:${KOGITO_VERSION}"
+ENV LD_LIBRARY_PATH="/home/kogito/.local/bin/jep:$LD_LIBRARY_PATH"
 
 CMD ["/home/kogito/launch/run-app-devmode.sh"]


### PR DESCRIPTION
@hbelmiro PTAL. The only remaining issue I found is this when I attempt to process an image:
```
Caused by: java.net.UnknownHostException: yolo-model-model-project.apps.hbelmiro.dev.datahub.redhat.com: Name or service not known
	at java.base/java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method)
	at java.base/java.net.InetAddress$PlatformNameService.lookupAllHostAddr(InetAddress.java:930)
	at java.base/java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1543)
	at java.base/java.net.InetAddress$NameServiceAddresses.get(InetAddress.java:848)
	at java.base/java.net.InetAddress.getAllByName0(InetAddress.java:1533)
	at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1386)
	at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1307)
```
Which I suspect is due to the host not reachable from my cluster, although I can ping it internally.